### PR TITLE
Added opt-in Stylelint based stylesheet linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 2.1.0
+**Improvements**
+  - `swig-lint`
+
+    It is now possible to opt-in for a Stylelint based linting of CSS/LESS files, via the new
+    `--use-stylelint` flag.
+
+
 ### 2.0.0
 **General Notes**
  - Aggregated all Swig related packages under one repository.

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.36",
+  "lerna": "2.0.0-beta.38",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-eslint": "^7.1.1",
     "eslint": "^3.15.0",
     "eslint-plugin-import": "^2.2.0",
-    "lerna": "2.0.0-beta.36"
+    "lerna": "^2.0.0-beta.38"
   },
   "scripts": {
     "fix": "eslint packages/ --format=codeframe --fix",

--- a/packages/swig-lint/README.md
+++ b/packages/swig-lint/README.md
@@ -8,10 +8,26 @@ Meant to be used via the [Swig CLI][1], just run:
 swig lint
 ```
 
+You can also instruct the CSS linter to use a different engine (default is an ancient version
+of [Lesshint][2]), namely [Stylelint][3], like so:
+
+```
+swig lint --use-stylelint
+```
+
+In this case you shall provide the linter a `.stylelintrc.yml` file with the necessary Stylelint
+configuration.
+
+By using [Stylelint][3] you can now also specify files to ignore (previously not possible), using the
+special `.stylelintignore` config file, which uses a `.gitignore`-like syntax.
+
+
 ## TODO
 
  - Add more helpful information on the README (like list of JS/CSS rules) and
  how to override them.
 
 
- [1]:https://www.npmjs.com/package/@gilt-tech/swig
+[1]:https://www.npmjs.com/package/@gilt-tech/swig
+[2]:https://github.com/gilt/lesshint
+[3]:https://stylelint.io/

--- a/packages/swig-lint/package.json
+++ b/packages/swig-lint/package.json
@@ -22,6 +22,7 @@
     "gulp-handlebars": "^4.0.0",
     "gulp-insert": "^0.5.0",
     "gulp-lesshint": "git://github.com/gilt/gulp-lesshint.git",
+    "gulp-stylelint": "^3.9.0",
     "gulp-util": "^3.0.8",
     "jshint-stylish": "^2.2.1",
     "through2": "^2.0.3",


### PR DESCRIPTION
Improved `swig-lint`

It is now possible to opt-in for a Stylelint based linting of CSS/LESS files, via the new `--use-stylelint` flag.
