### PR TITLE
FECK-1905: Update Swig Spec to support a custom source folder

### DIFF
--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -27,7 +27,6 @@ module.exports = function (gulp, swig) {
   let scripts = [];
   const fixtures = [];
   const packageName = _.isEmpty(swig.pkg) ? '' : swig.pkg.name.replace('@gilt-tech/', '');
-  let specsPath = '';
   let tempPath = '';
   let requireBasePath = '';
   let servers; // populated by mock-apidoc task
@@ -65,8 +64,8 @@ module.exports = function (gulp, swig) {
       specPath = swig.argv.spec;
     } else if (swig.pkg.gilt && (swig.pkg.gilt.specPath || swig.pkg.gilt.publicPath)) {
       specPath = swig.pkg.gilt.specPath || swig.pkg.gilt.publicPath;
-    } else if(swig.argv.src) {
-      specPath = `${swig.argv.src}/spec`
+    } else if (swig.argv.src) {
+      specPath = `${swig.argv.src}/spec`;
     } else {
       specPath = `${swig.target.path}/public/spec`;
     }
@@ -147,9 +146,7 @@ module.exports = function (gulp, swig) {
 
   gulp.task('spec-templates', ['spec-mock-apidoc'], (done) => {
     const srcPath = getSrcDirectory();
-    let specsPath = getSpecDirectory();
-
-    console.log('specsPath:', specsPath);
+    const specsPath = getSpecDirectory();
 
     swig.log.info('', 'Enumerating Templates...');
 
@@ -167,8 +164,6 @@ module.exports = function (gulp, swig) {
       // it's a bit wonky for modules, but follows webapp structure
       tmp = path.join(swig.temp, 'install', swig.argv.module, 'public/templates/', swig.argv.module);
     }
-
-    console.log('destPath: ', destPath);
 
     hbsGlob = [
       path.join(hbsPath, '/**/*.handlebars'),
@@ -232,6 +227,7 @@ module.exports = function (gulp, swig) {
   });
 
   gulp.task('spec-run', ['spec-templates'], () => {
+    const specsPath = getSpecDirectory();
     const defaultFramework = 'jasmine';
     const specs = [];
     const runnerPath = path.join(specsPath, '/runner');
@@ -308,7 +304,6 @@ module.exports = function (gulp, swig) {
   });
 
   gulp.task('spec', function (done) {
-    const srcPath = getSrcDirectory();
     const specPath = getSpecDirectory();
     let _specsPath = path.join(specPath, '/', packageName);
     let installTask = 'install-noop';
@@ -344,7 +339,6 @@ module.exports = function (gulp, swig) {
     }
     specTasks.push('spec-run');
     specTasks.push(done);
-
 
     swig.seq.apply(this, specTasks);
   });

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -43,7 +43,7 @@ module.exports = function (gulp, swig) {
     }
   });
 
-  function getSrcDirectory () {
+  function getSrcDirectory() {
     let srcPath;
 
     if (swig.argv.src) {

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -38,20 +38,27 @@ module.exports = function (gulp, swig) {
       '--module, --m': 'Specifies the target module to run specs for, within the working directory.\nIf not specified, the task assumes the working directory is a web app.',
       '--targetExperience': 'Optional. The target experience to run specs for;\nfull, intermediate, or minimal',
       '--browser': 'Optional. Opens the specs in a browser window instead of running them in the console.',
-      '--verbose': 'Optional. Shows additional infomration on the process, including console output from PhantomJS.'
+      '--verbose': 'Optional. Shows additional infomration on the process, including console output from PhantomJS.',
+      '--src': 'Specify the public folder'
     }
   });
+
+  function getSrcDirectory(){
+    return swig.argv.src || `${swig.target.path}/public`;
+  }
 
   // Loading swig dependencies
   swig.loadPlugins(require('./package.json').dependencies);
 
   gulp.task('spec-setup', (done) => {
+    const srcPath = getSrcDirectory();
+
     swig.log.task('Initializing Specs');
 
     swig.log.info('', 'Enumerating Dependencies...');
 
     // add main.js to the mix.
-    let mainJsPath = path.join(swig.target.path, 'public/js/', packageName, 'main.js');
+    let mainJsPath = path.join(srcPath, '/js/', packageName, 'main.js');
 
     // main.js is created in the system tempdir for modules.
     if (swig.project.type !== 'webapp') {
@@ -60,8 +67,8 @@ module.exports = function (gulp, swig) {
 
     scripts.push(mainJsPath);
 
-    specsPath = path.join(swig.target.path, 'public/spec/', packageName);
-    requireBasePath = path.join(swig.target.path, 'public/js/', packageName);
+    specsPath = path.join(srcPath, '/spec/', packageName);
+    requireBasePath = path.join(srcPath, '/js/', packageName);
 
     if (swig.project.type !== 'webapp') {
       // if we're in a ui-* modules repo
@@ -111,11 +118,13 @@ module.exports = function (gulp, swig) {
   });
 
   gulp.task('spec-templates', ['spec-mock-apidoc'], (done) => {
+    const srcPath = getSrcDirectory();
+
     swig.log.info('', 'Enumerating Templates...');
 
     const handlebars = require('handlebars');
-    let hbsPath = path.join(swig.target.path, 'public/templates/', packageName, 'src');
-    let destPath = path.join(swig.target.path, 'public/spec/', packageName, '/runner');
+    let hbsPath = path.join(srcPath, '/templates/', packageName, 'src');
+    let destPath = path.join(srcPath, '/spec/', packageName, '/runner');
     let tmp;
     let fileCount = 0;
     let hbsGlob = [];
@@ -266,7 +275,8 @@ module.exports = function (gulp, swig) {
   });
 
   gulp.task('spec', function (done) {
-    let _specsPath = path.join(swig.target.path, 'public/spec/', packageName);
+    const srcPath = getSrcDirectory();
+    let _specsPath = path.join(swig.target.path, srcPath, '/spec/', packageName);
     let installTask = 'install-noop';
 
     if (swig.project.type !== 'webapp') {

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -43,7 +43,7 @@ module.exports = function (gulp, swig) {
     }
   });
 
-  function getSrcDirectory(){
+  function getSrcDirectory () {
     let srcPath;
 
     if (swig.argv.src) {

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -39,7 +39,8 @@ module.exports = function (gulp, swig) {
       '--targetExperience': 'Optional. The target experience to run specs for;\nfull, intermediate, or minimal',
       '--browser': 'Optional. Opens the specs in a browser window instead of running them in the console.',
       '--verbose': 'Optional. Shows additional infomration on the process, including console output from PhantomJS.',
-      '--src': 'Specify the public folder'
+      '--src': 'Specify the public folder',
+      '--spec': 'Specify the spec folder'
     }
   });
 

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -57,11 +57,28 @@ module.exports = function (gulp, swig) {
     return srcPath;
   }
 
+  function getSpecDirectory() {
+    let specPath;
+
+    if (swig.argv.spec) {
+      specPath = swig.argv.spec;
+    } else if (swig.pkg.gilt && (swig.pkg.gilt.specPath || swig.pkg.gilt.publicPath)) {
+      specPath = swig.pkg.gilt.specPath || swig.pkg.gilt.publicPath;
+    } else if(swig.argv.src) {
+      specPath = `${swig.argv.src}/spec`
+    } else {
+      specPath = `${swig.target.path}/public/spec`;
+    }
+
+    return specPath;
+  }
+
   // Loading swig dependencies
   swig.loadPlugins(require('./package.json').dependencies);
 
   gulp.task('spec-setup', (done) => {
     const srcPath = getSrcDirectory();
+    let specsPath = getSpecDirectory();
 
     swig.log.task('Initializing Specs');
 
@@ -77,18 +94,18 @@ module.exports = function (gulp, swig) {
 
     scripts.push(mainJsPath);
 
-    specsPath = path.join(srcPath, '/spec/', packageName);
     requireBasePath = path.join(srcPath, '/js/', packageName);
 
     if (swig.project.type !== 'webapp') {
       // if we're in a ui-* modules repo
       tempPath = path.join(swig.temp, 'install', packageName);
-      specsPath = path.join(swig.target.path, 'spec/');
       requireBasePath = path.join(tempPath, 'public/js', packageName);
 
       // what we're doing here is telling require to use the files local to /js
       // for the module first, rather than what's in the temp ui-install dir.
       scripts = scripts.concat(glob.sync(path.join(swig.target.path, 'js/**/*.js')));
+    } else {
+      specsPath = path.join(specsPath, '/', packageName);
     }
 
     // load any fixtures in /specs/fixtures
@@ -129,23 +146,28 @@ module.exports = function (gulp, swig) {
 
   gulp.task('spec-templates', ['spec-mock-apidoc'], (done) => {
     const srcPath = getSrcDirectory();
+    let specsPath = getSpecDirectory();
+
+    console.log('specsPath:', specsPath);
 
     swig.log.info('', 'Enumerating Templates...');
 
     const handlebars = require('handlebars');
     let hbsPath = path.join(srcPath, '/templates/', packageName, 'src');
-    let destPath = path.join(srcPath, '/spec/', packageName, '/runner');
+    let destPath = path.join(specsPath, '/', packageName, '/runner');
     let tmp;
     let fileCount = 0;
     let hbsGlob = [];
 
     if (swig.project.type !== 'webapp') {
       hbsPath = path.join(swig.target.path, 'templates');
-      destPath = path.join(swig.target.path, 'spec/runner');
+      destPath = path.join(specsPath, '/runner');
 
       // it's a bit wonky for modules, but follows webapp structure
       tmp = path.join(swig.temp, 'install', swig.argv.module, 'public/templates/', swig.argv.module);
     }
+
+    console.log('destPath: ', destPath);
 
     hbsGlob = [
       path.join(hbsPath, '/**/*.handlebars'),
@@ -286,12 +308,13 @@ module.exports = function (gulp, swig) {
 
   gulp.task('spec', function (done) {
     const srcPath = getSrcDirectory();
-    let _specsPath = path.join(srcPath, '/spec/', packageName);
+    const specPath = getSpecDirectory();
+    let _specsPath = path.join(specPath, '/', packageName);
     let installTask = 'install-noop';
 
     if (swig.project.type !== 'webapp') {
       // if we're in a ui-* modules repo
-      _specsPath = path.join(srcPath, 'spec/');
+      _specsPath = path.join(specPath, '/');
     }
 
     if (swig.argv.module || swig.argv.m) {

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -44,7 +44,17 @@ module.exports = function (gulp, swig) {
   });
 
   function getSrcDirectory(){
-    return swig.argv.src || `${swig.target.path}/public`;
+    let srcPath;
+
+    if (swig.argv.src) {
+      srcPath = swig.argv.src;
+    } else if (swig.pkg.gilt && (swig.pkg.gilt.srcPath || swig.pkg.gilt.publicPath)) {
+      srcPath = swig.pkg.gilt.srcPath || swig.pkg.gilt.publicPath;
+    } else {
+      srcPath = `${swig.target.path}/public`;
+    }
+
+    return srcPath;
   }
 
   // Loading swig dependencies
@@ -276,12 +286,12 @@ module.exports = function (gulp, swig) {
 
   gulp.task('spec', function (done) {
     const srcPath = getSrcDirectory();
-    let _specsPath = path.join(swig.target.path, srcPath, '/spec/', packageName);
+    let _specsPath = path.join(srcPath, '/spec/', packageName);
     let installTask = 'install-noop';
 
     if (swig.project.type !== 'webapp') {
       // if we're in a ui-* modules repo
-      _specsPath = path.join(swig.target.path, 'spec/');
+      _specsPath = path.join(srcPath, 'spec/');
     }
 
     if (swig.argv.module || swig.argv.m) {


### PR DESCRIPTION
Small update to Swig spec to support the src flag when running specs.

As requested by Gary for implementing swig into sbt ui-install, we need to add the ability to allow the public folder location to be changed using the `--src` flag.

Ticket: https://jira.gilt.com/browse/FECK-1905