### PR TITLE
Add husky hooks precommit to top level

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,3 +6,6 @@ rules:
   "no-restricted-syntax": "off"
   "no-param-reassign": "off"
   "no-console": "off"
+  "import/no-unresolved": 0
+  "no-continue": 0
+  "consistent-return": 0

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -6,6 +6,5 @@ rules:
   "no-restricted-syntax": "off"
   "no-param-reassign": "off"
   "no-console": "off"
-  "import/no-unresolved": 0
   "no-continue": 0
   "consistent-return": 0

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 /.package.json
 packages/swig-cli/.update
 packages/*/yarn.lock
+/.eslintcache

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-eslint": "^7.1.1",
     "eslint": "^3.15.0",
     "eslint-plugin-import": "^2.2.0",
+    "husky": "^0.13.3",
     "lerna": "2.0.0-beta.38"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "fix": "eslint packages/ --format=codeframe --fix",
     "lint": "eslint packages/ --format=codeframe",
-    "bootstrap": "lerna bootstrap --npm-client=yarn"
+    "bootstrap": "lerna bootstrap --npm-client=yarn",
+    "precommit": "eslint ./ --color --cache --ignore-pattern .eslintignore --rule 'import/no-unresolved: 0' --rule 'no-continue: 0' --rule 'consistent-return: 0'; exit 0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "fix": "eslint packages/ --format=codeframe --fix",
     "lint": "eslint packages/ --format=codeframe",
     "bootstrap": "lerna bootstrap --npm-client=yarn",
-    "precommit": "eslint ./ --color --cache --ignore-pattern .gitignore; exit 0"
+    "precommit": "eslint ./ --color --cache --ignore-pattern .gitignore --rule 'import/no-unresolved: 0'; exit 0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "fix": "eslint packages/ --format=codeframe --fix",
     "lint": "eslint packages/ --format=codeframe",
     "bootstrap": "lerna bootstrap --npm-client=yarn",
-    "precommit": "eslint ./ --color --cache --ignore-pattern .eslintignore --rule 'import/no-unresolved: 0' --rule 'no-continue: 0' --rule 'consistent-return: 0'; exit 0"
+    "precommit": "eslint ./ --color --cache --ignore-pattern .gitignore; exit 0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "fix": "eslint packages/ --format=codeframe --fix",
     "lint": "eslint packages/ --format=codeframe",
     "bootstrap": "lerna bootstrap --npm-client=yarn",
-    "precommit": "eslint ./ --color --cache --ignore-pattern .gitignore --rule 'import/no-unresolved: 0'; exit 0"
+    "precommit": "npm run lint -- --cache --rule 'import/no-unresolved: 0'"
   }
 }


### PR DESCRIPTION
I have added a precommit hook to just the top level of this repo,
This allows us to run checks over the SWIG app as a whole
It would be good to add this to the swig init for apps it is deployed into, this is just for updates to SWIG and to make them easier
I have also set the exit to 0 so it won't prevent commits or throw errors but it will give errors and warnings found by ESLint allowing us to fix before pushing

Due to the existing code I have omitted the following checks
- Checks for lower level package requires
- Using continues to reset a while loop 
- Consistent Return, some functions appear as Process and some as Mutative, ESLint sees this as bad practice