### PR TITLE
chore: switch to execa + split2. npm v5 compatibility.

### DIFF
--- a/packages/swig-bundle/index.js
+++ b/packages/swig-bundle/index.js
@@ -63,6 +63,7 @@ module.exports = function (gulp, swig) {
   const path = require('path');
   const globby = require('globby');
   const fs = require('fs');
+  const execa = require('execa');
   const merge = require('merge-stream');
   const concat = require('./lib/concat-experience');
   const sourcemaps = require('gulp-sourcemaps');
@@ -145,7 +146,7 @@ module.exports = function (gulp, swig) {
       `cd ${swig.temp}`,
       `npm la --json --quiet${name || ''}`
     ];
-    const raw = yield swig.exec(commands.join('; '));
+    const raw = yield execa.shell(commands.join('; '));
     const result = JSON.parse(raw.stdout);
 
     cleanTree(result);

--- a/packages/swig-bundle/package.json
+++ b/packages/swig-bundle/package.json
@@ -20,6 +20,7 @@
     "globby": "^6.1.0",
     "gulp-sourcemaps": "^2.0.0",
     "gulp-util": "^3.0.1",
+    "execa": "^0.6.0",
     "merge-stream": "^1.0.1",
     "source-map": "^0.5.6",
     "sprintf-js": "^1.0.2",

--- a/packages/swig-install/package.json
+++ b/packages/swig-install/package.json
@@ -22,7 +22,9 @@
     "globby": "^6.1.0",
     "gulp-rimraf": "^0.2.1",
     "gulp-util": "^3.0.8",
+    "execa": "^0.6.0",
     "rimraf": "^2.6.0",
+    "split2": "^2.1.1",
     "thunkify": "^2.1.2",
     "underscore": "^1.8.3"
   },

--- a/packages/swig-publish/package.json
+++ b/packages/swig-publish/package.json
@@ -19,9 +19,11 @@
     "co": "^4.0.0",
     "globby": "^6.1.0",
     "gulp-util": "^3.0.3",
+    "execa": "^0.6.0",
     "prompt": "^1.0.0",
     "rimraf": "^2.6.0",
     "simple-git": "^1.66.0",
+    "split2": "^2.1.1",
     "thunkify": "^2.1.2",
     "underscore": "^1.8.3"
   },

--- a/packages/swig-stub/index.js
+++ b/packages/swig-stub/index.js
@@ -16,6 +16,8 @@ module.exports = function (gulp, swig) {
   const _ = require('underscore');
   const path = require('path');
   const co = require('co');
+  const execa = require('execa');
+  const split = require('split2');
   const prettyjson = require('prettyjson');
   const stubs = require('./lib/stubs');
   const inquirer = require('inquirer');
@@ -62,11 +64,15 @@ module.exports = function (gulp, swig) {
           swig.log();
 
           swig.log.info('', 'Starting `npm install`...\n');
-          result = yield swig.exec(`cd ${destPath}; ${installCommand}`, null, {
-            stdout: function (out) {
-              swig.log(out.trim().grey);
-            }
+
+          const installProcess = execa.shell(`cd ${destPath}; ${installCommand}`);
+
+          // Remap stdout with some swig.log love
+          installProcess.stdout.pipe(split()).on('data', (line) => {
+            swig.log(line.trim().grey);
           });
+
+          result = yield installProcess;
 
           swig.log();
 

--- a/packages/swig-stub/package.json
+++ b/packages/swig-stub/package.json
@@ -16,10 +16,12 @@
   "license": "MIT",
   "dependencies": {
     "co": "^4.0.0",
+    "execa": "^0.6.0",
     "gulp-util": "^3.0.8",
     "inquirer": "^3.0.1",
     "mustache": "^2.3.0",
     "prettyjson": "^1.2.1",
+    "split2": "^2.1.1",
     "through2": "^2.0.3",
     "underscore": "^1.8.3"
   },

--- a/packages/swig-util/lib/exec.js
+++ b/packages/swig-util/lib/exec.js
@@ -17,7 +17,6 @@ module.exports = function (swig) {
   *  copied from https://raw.githubusercontent.com/visionmedia/co-exec/master/index.js
   *  since they don't support returning stderr just yet.
   */
-
   const _ = require('underscore');
   const exec = require('child_process').exec;
 
@@ -52,6 +51,8 @@ module.exports = function (swig) {
 
   // return a thunk for yield/generator functionality
   swig.exec = function swigExec(cmd, opts, options) {
+    console.log('DEPRECATED: swig.exec is deprecated as of v2.5.3. Please switch to something better like `execa` by Sindre Sorhus http://github.com/sindresorhus/execa');
+
     opts = _.extend(opts || {}, { maxBuffer: 20 * 1024 * 1024 }); // increase max buffer to 20mb
 
     return function swigExecThunk(done) {


### PR DESCRIPTION
Fixed potential issue with npm v5 breaking changes to its output.

We currently scrape npm's output on some occasions to take informations we need. 

npm v5 changed some of its logging strings, therefore an update of our scraper was necessary.

Also, `swig.exec` was crashing spectacularly when running this:

```
       `npm la --json --quiet`		
```

I didn't dig into it too deeply, I just switched to `execa` by Sindre Sorhus (Papa Bless him), which _Just Works™_