### PR TITLE
Make "swig run" blocking, correct task execution order

### DIFF
--- a/packages/swig-run/index.js
+++ b/packages/swig-run/index.js
@@ -141,7 +141,7 @@ module.exports = function (gulp, swig) {
     if (swig.watch.watchers.length > 0) swig.log.success(null, 'File watching enabled.');
   });
 
-  gulp.task('run', ['init'], (cb) => {
+  gulp.task('run', ['init'], (done) => {
     let errors;
 
     swig.log();
@@ -156,7 +156,7 @@ module.exports = function (gulp, swig) {
 
         swig.log.task('Running app');
         swig.log();
-        run(cb);
+        run(done);
       } else {
         swig.log.error('swig-app', `Couldn't start your app due to the following:\n${errors.join('\n')}`);
       }
@@ -165,9 +165,9 @@ module.exports = function (gulp, swig) {
     }
   });
 
-  gulp.task('init', (cb) => {
+  gulp.task('init', (done) => {
     // Initialise scripts and stylesheets, setup watchers when done.
     // Once all tasks complete, callback - this is required to make swig.seq blocking
-    swig.seq(['init-scripts', 'init-styles'], 'watch', cb);
+    swig.seq(['init-scripts', 'init-styles'], 'watch', done);
   });
 };

--- a/packages/swig-run/index.js
+++ b/packages/swig-run/index.js
@@ -165,8 +165,9 @@ module.exports = function (gulp, swig) {
     }
   });
 
-  gulp.task('init', () => {
+  gulp.task('init', (cb) => {
     // Initialise scripts and stylesheets, setup watchers when done.
-    swig.seq(['init-scripts', 'init-styles'], 'watch');
+    // Once all tasks complete, callback - this is required to make swig.seq blocking
+    swig.seq(['init-scripts', 'init-styles'], 'watch', cb);
   });
 };


### PR DESCRIPTION
The gulp.task(task, dependencies, callback) methods second parameter is for dependencies and the intended behaviour is that it will block until all dependency tasks have complete executing.

/swig/packages/swig-run/index.js:144, "run" calls the init task as a dependency but it does not wait until init has complete. It calls init and then immediately executes the third argument - it's callback function - which initialises the application. The application then fails because the .js hasn't yet transpiled.

There two potential causes of the issue here:

1. There is a known Gulp 3.x bug where under certain conditions tasks do not wait for their dependencies to complete, this is documented [here](https://github.com/gulpjs/gulp/issues/899) and the project owner has no desire to fix it - I can't say for definite this is related to what we're experiencing here but potentially migrating to Gulp 4.x may resolve this issue going forward.
2. Gulp isn't playing nice with the swig.seq method and is calling back before it has finished executing - I've confirmed this behaviour. Using native gulp methods within the task instead of swig.seq and calling back after the "end" event fires worked as expected - the dependency tasks are blocking.

The solution here is to add a callback parameter to the tasks callback function and then provide it as the final argument for swig.seq which appears to recognise it is a function - and not a task-string - and execute it once all tasks have complete sequentially making the "init" task blocking.

I'm not completely happy with the solution as the terminal output is still out of order but this issue is no longer a blocker. Migrating to Gulp 4.x might be worth considering, or potentially this can be solved by a more intelligent use of swig.seq.