### PR TITLE
NOJIRA: improve swig spec for non web projects

### DIFF
--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -66,7 +66,7 @@ module.exports = function (gulp, swig) {
       specPath = swig.pkg.gilt.specPath || swig.pkg.gilt.publicPath;
     } else if (swig.argv.src) {
       specPath = `${swig.argv.src}/spec`;
-    } else if(swig.project.type !== 'webapp') {
+    } else if (swig.project.type !== 'webapp') {
       specPath = `${swig.target.path}/spec`;
     } else {
       specPath = `${swig.target.path}/public/spec`;

--- a/packages/swig-spec/index.js
+++ b/packages/swig-spec/index.js
@@ -66,6 +66,8 @@ module.exports = function (gulp, swig) {
       specPath = swig.pkg.gilt.specPath || swig.pkg.gilt.publicPath;
     } else if (swig.argv.src) {
       specPath = `${swig.argv.src}/spec`;
+    } else if(swig.project.type !== 'webapp') {
+      specPath = `${swig.target.path}/spec`;
     } else {
       specPath = `${swig.target.path}/public/spec`;
     }

--- a/packages/swig-spec/package.json
+++ b/packages/swig-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-spec",
   "description": "Runs specs (tests, expectations) for UI Modules and web apps.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "repository": "https://github.com/gilt/swig/tree/master/packages/swig-spec",
   "keywords": [
     "gulp",

--- a/packages/swig-spec/package.json
+++ b/packages/swig-spec/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@gilt-tech/swig-spec",
   "description": "Runs specs (tests, expectations) for UI Modules and web apps.",
-  "version": "2.6.2",
+  "version": "2.6.1",
   "repository": "https://github.com/gilt/swig/tree/master/packages/swig-spec",
   "keywords": [
     "gulp",


### PR DESCRIPTION
Small update to fix the spec directory method.

If testing a module, the specs exist in the `/spec` directory, but if a webapp then they exist in `/public/spec`

This update will ensure the swig-spec module is aware of this.