### PR TITLE
Uses a list of supported browsers across GILT apps

### DIFF
--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -41,7 +41,14 @@ const swig = {
     enabled: (!!argv.watch || !!argv.watchScripts),
     watchers: []
   },
-  browserslist: thisPkg.browserslist
+  get browserslist() {
+    const appPkg = swig.pkg;
+    // A default list of browser that should be supported in the front end app.
+    // This can be overridden locally in the target App by adding a `"browserslist"` field in its own `package.json`
+    const defaultBrowserslist = thisPkg.browserslist;
+
+    return appPkg.browserslist || defaultBrowserslist;
+  }
 };
 
 function load(moduleName) {

--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -41,6 +41,7 @@ const swig = {
     enabled: (!!argv.watch || !!argv.watchScripts),
     watchers: []
   },
+  browserslist: thisPkg.browserslist
 };
 
 function load(moduleName) {

--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -43,7 +43,7 @@ const swig = {
   },
   get browserslist() {
     const appPkg = swig.pkg;
-    // A default list of browser that should be supported in the front end app.
+    // A default list of browsers that should be supported in the front end app, based on https://github.com/ai/browserslist
     // This can be overridden locally in the target App by adding a `"browserslist"` field in its own `package.json`
     const defaultBrowserslist = thisPkg.browserslist;
 

--- a/packages/swig-cli/lib/pre-publish/less.js
+++ b/packages/swig-cli/lib/pre-publish/less.js
@@ -23,6 +23,7 @@ module.exports = function (log) {
   const glob = require('globby');
   const less = require('less');
   const postcss = require('postcss');
+  const swigCliPkg = require('../../package.json');
   const autoprefixer = require('autoprefixer');
 
   const cwd = process.cwd();
@@ -33,14 +34,6 @@ module.exports = function (log) {
   const packageName = pkg.name.replace('@gilt-tech/', '');
   const publishPath = cwd;
   const cssPath = path.join(publishPath, targetPath);
-  // TODO: we should centralize this. it is being used in different places already
-  const autoprefixerConfig = {
-    browsers: [
-      'last 2 versions',
-      'ie >= 11',
-      'iOS >= 8'
-    ]
-  };
 
   // (tmpdir)/swig/publish/(module.name)/../../install/(module.name)
   const installPath = path.join(os.tmpdir(), 'swig', '/install', packageName, '/public/css/', packageName);
@@ -106,7 +99,9 @@ module.exports = function (log) {
   // and do less than those in less.helpers. fun stuff.
   log.info('Note', 'Each file is prepended with an @import of less.helpers.');
 
-  const prefixer = postcss(autoprefixer(autoprefixerConfig));
+  const prefixer = postcss(autoprefixer({
+    browsers: swigCliPkg.browserslist
+  }));
 
   lessFiles.forEach((filePath) => {
     let contents;

--- a/packages/swig-cli/lib/pre-publish/less.js
+++ b/packages/swig-cli/lib/pre-publish/less.js
@@ -100,7 +100,7 @@ module.exports = function (log) {
   log.info('Note', 'Each file is prepended with an @import of less.helpers.');
 
   const prefixer = postcss(autoprefixer({
-    browsers: swigCliPkg.browserslist
+    browsers: pkg.browserslist || swigCliPkg.browserslist
   }));
 
   lessFiles.forEach((filePath) => {

--- a/packages/swig-cli/package.json
+++ b/packages/swig-cli/package.json
@@ -49,7 +49,6 @@
     "swig": "bin/swig"
   },
   "browserslist": [
-    "last 2 versions",
     "ie >= 11",
     "iOS >= 8"
   ]

--- a/packages/swig-cli/package.json
+++ b/packages/swig-cli/package.json
@@ -47,5 +47,10 @@
   },
   "bin": {
     "swig": "bin/swig"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "ie >= 11",
+    "iOS >= 8"
+  ]
 }

--- a/packages/swig-merge-css/index.js
+++ b/packages/swig-merge-css/index.js
@@ -21,22 +21,6 @@ const inlineImports = require('postcss-import');
 const autoprefixer = require('autoprefixer');
 const through2 = require('through2');
 
-const autoprefixerCfg = {
-  // https://github.com/postcss/autoprefixer#options
-  browsers: [
-    'last 2 versions',
-    'ie >= 11',
-    'iOS >= 8'
-  ],
-  // should Autoprefixer [remove outdated] prefixes. Default is true.
-  remove: true
-};
-const postcssPlugins = [
-  inlineImports,
-  autoprefixer(autoprefixerCfg),
-];
-
-
 module.exports = function (gulp, swig) {
   const basePath = path.join(swig.target.path, '/public/');
   const cssPath = path.join(basePath, '/css/', swig.target.name);
@@ -67,7 +51,10 @@ module.exports = function (gulp, swig) {
         paths: [cssPath],
         relativeUrls: false
       }))
-      .pipe(postcss(postcssPlugins))
+      .pipe(postcss(
+        inlineImports,
+        autoprefixer({ browsers: swig.browserslist }))
+      )
       .pipe(rename({ suffix: '.src' }))
       .pipe(sourcemaps.write('.'))
       .pipe(gulp.dest(cssPath))


### PR DESCRIPTION
The supported browsers list that has been centralized in `swig-cli/package.json`