### PR TITLE
Dont remove other less files in root of public/css

### DIFF
--- a/packages/swig-install/lib/public-directory.js
+++ b/packages/swig-install/lib/public-directory.js
@@ -34,7 +34,7 @@ module.exports = function (gulp, swig) {
       '!./public/**/{target}/**/config/**/*',
       '!./public/**/{target}/**/src',
       '!./public/**/{target}/**/src/**/*',
-      '!./public/css/{target}/main.less',
+      '!./public/css/{target}/*.less',
       '!./public/spec/{target}/**/*'
     ];
 


### PR DESCRIPTION
This is necessary to ensure web-mosaic can correctly publish dependencies to production.

In the mosaic we have too stylesheets:
1. Main.less - for the mosaic
2. mini_mosaic_main.less - for the mini mosaic

At the moment `swig-install` only takes main.less into account, this change will support multiple stylesheets.

Combining these files will cause a conflict as selectors are shared.