### PR TITLE
fix(swig-minify): fixed loading of swig-minify required plugins.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fix": "eslint packages/ --format=codeframe --fix",
     "lint": "eslint packages/ --format=codeframe",
     "bootstrap": "lerna bootstrap --npm-client=yarn",
-    "precommit": "npm run lint -- --cache --rule 'import/no-unresolved: 0'"
+    "precommit": "npm run lint -- --cache --rule 'import/no-unresolved: 0'",
+    "pub": "(npm run lint && lerna updated && lerna publish) || exit 0"
   }
 }

--- a/packages/swig-install/index.js
+++ b/packages/swig-install/index.js
@@ -104,7 +104,7 @@ module.exports = function (gulp, swig) {
   }
 
   function* local() {
-    if (swig.argv.module) {
+    if (swig.argv.module || swig.argv.skipNodeModules) {
       swig.log.info('', 'Skipping Node Modules');
       return;
     }

--- a/packages/swig-minify/index.js
+++ b/packages/swig-minify/index.js
@@ -25,6 +25,9 @@ const gutil = require('gulp-util');
 const babel = require('gulp-babel');
 
 module.exports = function (gulp, swig) {
+  // Loading swig dependencies
+  swig.loadPlugins(require('./package.json').dependencies);
+
   const basePath = path.join(swig.target.path, '/public/');
   function renameFile(file) {
     file.basename = `${file.basename.replace('.src', '')}.min`;


### PR DESCRIPTION
Also added a --skip-node-modules flag to swig-install (for apps that
already have an npm install step in their pipeline)

Also added a 'pub' script to easily publish packages