### PR TITLE
NOJIRA: Ensure transpile scripts will throw if error

### DIFF
--- a/packages/swig-transpile-scripts/index.js
+++ b/packages/swig-transpile-scripts/index.js
@@ -70,7 +70,11 @@ module.exports = function (gulp, swig) {
 
     let stream = gulp.src(from)
       .pipe(cache('scripts'))
-      .pipe(plumber())
+      .pipe(plumber({
+        errorHandler: (e) => {
+          throw new Error(e)
+        }
+      }))
       .pipe(map.init({
         loadMaps: true
       }));
@@ -138,7 +142,11 @@ module.exports = function (gulp, swig) {
 
     let stream = gulp.src(from)
       .pipe(cache('scripts'))
-      .pipe(plumber());
+      .pipe(plumber({
+        errorHandler: (e) => {
+          throw new Error(e)
+        }
+      }));
 
     if (swig.argv.verbose) {
       stream = stream.pipe(tap((file) => {

--- a/packages/swig-transpile-scripts/index.js
+++ b/packages/swig-transpile-scripts/index.js
@@ -72,7 +72,7 @@ module.exports = function (gulp, swig) {
       .pipe(cache('scripts'))
       .pipe(plumber({
         errorHandler: (e) => {
-          throw new Error(e)
+          throw new Error(e);
         }
       }))
       .pipe(map.init({
@@ -144,7 +144,7 @@ module.exports = function (gulp, swig) {
       .pipe(cache('scripts'))
       .pipe(plumber({
         errorHandler: (e) => {
-          throw new Error(e)
+          throw new Error(e);
         }
       }));
 

--- a/packages/swig-transpile-scripts/index.js
+++ b/packages/swig-transpile-scripts/index.js
@@ -16,7 +16,6 @@ module.exports = function (gulp, swig) {
   const babel = require('gulp-babel');
   const path = require('path');
   const tap = require('gulp-tap');
-  const plumber = require('gulp-plumber');
   const replace = require('gulp-replace');
   const map = require('gulp-sourcemaps');
   const transformModules = require('./lib/transform-es2015-modules-gilt');
@@ -70,11 +69,6 @@ module.exports = function (gulp, swig) {
 
     let stream = gulp.src(from)
       .pipe(cache('scripts'))
-      .pipe(plumber({
-        errorHandler: (e) => {
-          throw new Error(e);
-        }
-      }))
       .pipe(map.init({
         loadMaps: true
       }));
@@ -141,12 +135,7 @@ module.exports = function (gulp, swig) {
     swig.log.task('Transpiling server-side scripts');
 
     let stream = gulp.src(from)
-      .pipe(cache('scripts'))
-      .pipe(plumber({
-        errorHandler: (e) => {
-          throw new Error(e);
-        }
-      }));
+      .pipe(cache('scripts'));
 
     if (swig.argv.verbose) {
       stream = stream.pipe(tap((file) => {

--- a/packages/swig-transpile-scripts/package.json
+++ b/packages/swig-transpile-scripts/package.json
@@ -24,7 +24,6 @@
     "glob": "^7.1.1",
     "gulp-babel": "6.x.x",
     "gulp-cached": "^1.1.1",
-    "gulp-plumber": "^1.1.0",
     "gulp-replace": "^0.5.4",
     "gulp-sourcemaps": "^2.0.0",
     "gulp-tap": "^0.1.3",


### PR DESCRIPTION
Small update.

Ensure `transpile-scripts` will throw if an error occurs.

This related to swig running in UI-build, `transpile-scripts` needs to throw if something is wrong or else the deploy will continue.