### PR TITLE
Randomise tmp folder

### DIFF
--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -162,7 +162,7 @@ function findTarget() {
     repo: swig.argv.repo || path.basename(swig.cwd)
   };
 
-  // Set random folder incase of multiple deploys
+  // Set the package name for the tmp folder incase of multiple deploys
   swig.temp = path.join(os.tmpdir(), `swig-${swig.target.name}`);
 }
 

--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -101,7 +101,10 @@ function setupPaths() {
 
   swig.home = swigPath;
   swig.cwd = process.cwd();
-  swig.temp = path.join(os.tmpdir(), 'swig');
+
+  // Set random folder incase of multiple deploys
+  const random = new Date().getTime() + Math.random();
+  swig.temp = path.join(os.tmpdir(), `swig-${random}`);
 }
 
 function findSwigRc() {

--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -103,8 +103,9 @@ function setupPaths() {
   swig.cwd = process.cwd();
 
   // Set random folder incase of multiple deploys
-  const random = new Date().getTime() + Math.random();
-  swig.temp = path.join(os.tmpdir(), `swig-${random}`);
+  const packageName = swig.pkg ? swig.pkg.name : '';
+  console.log(packageName);
+  swig.temp = path.join(os.tmpdir(), `swig-${packageName}`);
 }
 
 function findSwigRc() {

--- a/packages/swig-cli/index.js
+++ b/packages/swig-cli/index.js
@@ -101,11 +101,6 @@ function setupPaths() {
 
   swig.home = swigPath;
   swig.cwd = process.cwd();
-
-  // Set random folder incase of multiple deploys
-  const packageName = swig.pkg ? swig.pkg.name : '';
-  console.log(packageName);
-  swig.temp = path.join(os.tmpdir(), `swig-${packageName}`);
 }
 
 function findSwigRc() {
@@ -166,6 +161,9 @@ function findTarget() {
     name: swig.argv.module || (swig.pkg && swig.pkg.name) || path.basename(target),
     repo: swig.argv.repo || path.basename(swig.cwd)
   };
+
+  // Set random folder incase of multiple deploys
+  swig.temp = path.join(os.tmpdir(), `swig-${swig.target.name}`);
 }
 
 // allows a task to tell swig about itself


### PR DESCRIPTION
Small fix to ensure tmp folder is unique.

Bug occurred when deploying apps at the same time on Jenkins and when command `npm la --json --quiet` was run