### PR TITLE
NOJIRA: fix tmp dir for pre publish task

### DIFF
--- a/packages/swig-cli/lib/pre-publish/less.js
+++ b/packages/swig-cli/lib/pre-publish/less.js
@@ -36,7 +36,8 @@ module.exports = function (log) {
   const cssPath = path.join(publishPath, targetPath);
 
   // (tmpdir)/swig/publish/(module.name)/../../install/(module.name)
-  const installPath = path.join(os.tmpdir(), 'swig', '/install', packageName, '/public/css/', packageName);
+  // should be using swig-[project name]
+  const installPath = path.join(os.tmpdir(), `swig-${packageName}`, '/install', packageName, '/public/css/', packageName);
 
   const _lessPath = path.join(publishPath, '_less');
   const options = { paths: [installPath], relativeUrls: false };


### PR DESCRIPTION
Forgot to update the tmp dir for the pre publish task.

This will ensure the correct folder is used following the structure `swig-[project name]`
 
__Only swig@2.9.1__ is affected